### PR TITLE
support for dell hwt added

### DIFF
--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -11,9 +11,12 @@ module Fluent
     config_param :coloregion, :string
     config_param :username, :string
     config_param :passwordFile, :string
+    config_param :hardware, :string, :default => "SDFLEX"
 
     def configure(conf)
       super
+        @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC"]
+        @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup"]
     end
 
     def start
@@ -23,9 +26,9 @@ module Fluent
     def filter(tag, time, record)
      begin
       # REMOTE_ADDR is the IP the event was sent from
-      rmcSN = getRMCSerialNumber(record["REMOTE_ADDR"])
-      if tag == "redfish.alert"
-        rgSN = getRackGroupSerialNumber(record["REMOTE_ADDR"])
+      rmcSN = getMachineIdentifier(record["REMOTE_ADDR"])
+      if tag.include? "alert"
+        rgSN = getRackGroupIdentifier(record["REMOTE_ADDR"])
       end
      rescue SecurityError => se
       record["error"] = "Error calling redfish API: #{se.message}"
@@ -56,13 +59,21 @@ module Fluent
       end
     end
 
-    def getRMCSerialNumber(host)
-      res = callRedfishGetAPI(host, "Chassis/RMC")
+    #we are using nodeID as the unique identifier for dell iDRAC
+    #also, for dell nodeID=SKU=ChassisServiceTag but differs from SN
+    def getMachineIdentifier(host)
+      res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      if @hardware == "Dell_PowerEdge_iDRAC"
+        return res["SKU"]
+      end
       return res["SerialNumber"]
     end
 
-    def getRackGroupSerialNumber(host)
-      res = callRedfishGetAPI(host, "Chassis/RackGroup")
+    def getRackGroupIdentifier(host)
+      res = callRedfishGetAPI(host, @deviceRackURI[hardware])
+      if @hardware == "Dell_PowerEdge_iDRAC"
+        return res["SKU"]
+      end
       return res["SerialNumber"]
     end
 

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -16,6 +16,7 @@ module Fluent
       super
         @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC"]
         @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup"]
+        @deviceIDField = Hash["Dell_PowerEdge_iDRAC"=>"SKU", "SDFLEX" => "SerialNumber"]
     end
 
     def start
@@ -23,19 +24,24 @@ module Fluent
     end
 
     def filter(tag, time, record)
-     begin
+      begin
       # REMOTE_ADDR is the IP the event was sent from
       rmcSN = getMachineIdentifier(record["REMOTE_ADDR"])
-      if tag.include? "alert"
+      if tag == "redfish.alert"
         rgSN = getRackGroupIdentifier(record["REMOTE_ADDR"])
       end
-     rescue SecurityError => se
-      record["error"] = "Error calling redfish API: #{se.message}"
-     end
-     record["RMCSerialNumber"] = rmcSN
-     # BaseChassisSerialNumber is used as the identifier by OEMs
-     record["BaseChassisSerialNumber"] = rgSN
-     record
+      rescue SecurityError => se
+        record["error"] = "Error calling redfish API: #{se.message}"
+      end
+      if @hardware == "Dell_PowerEdge_iDRAC"
+        record["ProductID"] = rmcSN
+        record["PowerState"] = getPowerState(record["REMOTE_ADDR"])
+      else
+        record["RMCSerialNumber"] = rmcSN
+        # BaseChassisSerialNumber is used as the identifier by OEMs
+        record["BaseChassisSerialNumber"] = rgSN
+      end
+      record
     end
 
     def callRedfishGetAPI(host, resourceURI)
@@ -51,26 +57,28 @@ module Fluent
 
       response = https.request(request)
 
-      if response.code == "200"
+      if response.code == "200" 
         return JSON.parse(response.body)
       else 
+        puts "Response Body: #{response.body}"
+        puts "Status code: #{response.statuscode}"
         raise SecurityError
       end
     end
 
-    #we are using nodeID as the unique identifier for dell iDRAC
-    #also, for dell nodeID=SKU=ChassisServiceTag but differs from SN
     def getMachineIdentifier(host)
       res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-      if @hardware == "Dell_PowerEdge_iDRAC"
-        return res["SKU"]
-      end
-      return res["SerialNumber"]
+      return res[@deviceIDField[hardware]]
     end
 
     def getRackGroupIdentifier(host)
       res = callRedfishGetAPI(host, @deviceRackURI[hardware])
-      return res["SerialNumber"]
+      return res[@deviceIDField[hardware]]
+    end
+
+    def getPowerState(host)
+      res = callRedfishGetAPI(host, @deviceRackURI[hardware])
+      return res["PowerState"]
     end
 
     def getPassword()

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -16,7 +16,6 @@ module Fluent
       super
         @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC"]
         @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup"]
-        @deviceIDField = Hash["Dell_PowerEdge_iDRAC"=>"SKU", "SDFLEX" => "SerialNumber"]
     end
 
     def start
@@ -24,24 +23,19 @@ module Fluent
     end
 
     def filter(tag, time, record)
-      begin
+     begin
       # REMOTE_ADDR is the IP the event was sent from
       rmcSN = getMachineIdentifier(record["REMOTE_ADDR"])
-      if tag == "redfish.alert"
+      if tag.include? "alert"
         rgSN = getRackGroupIdentifier(record["REMOTE_ADDR"])
       end
-      rescue SecurityError => se
-        record["error"] = "Error calling redfish API: #{se.message}"
-      end
-      if @hardware == "Dell_PowerEdge_iDRAC"
-        record["ProductID"] = rmcSN
-        #record["PowerState"] = getPowerState(record["REMOTE_ADDR"])
-      else
-        record["RMCSerialNumber"] = rmcSN
-        # BaseChassisSerialNumber is used as the identifier by OEMs
-        record["BaseChassisSerialNumber"] = rgSN
-      end
-      record
+     rescue SecurityError => se
+      record["error"] = "Error calling redfish API: #{se.message}"
+     end
+     record["RMCSerialNumber"] = rmcSN
+     # BaseChassisSerialNumber is used as the identifier by OEMs
+     record["BaseChassisSerialNumber"] = rgSN
+     record
     end
 
     def callRedfishGetAPI(host, resourceURI)
@@ -57,28 +51,26 @@ module Fluent
 
       response = https.request(request)
 
-      if response.code == "200" 
+      if response.code == "200"
         return JSON.parse(response.body)
       else 
-        puts "Response Body: #{response.body}"
-        puts "Status code: #{response.statuscode}"
         raise SecurityError
       end
     end
 
+    #we are using nodeID as the unique identifier for dell iDRAC
+    #also, for dell nodeID=SKU=ChassisServiceTag but differs from SN
     def getMachineIdentifier(host)
       res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-      return res[@deviceIDField[hardware]]
+      if @hardware == "Dell_PowerEdge_iDRAC"
+        return res["SKU"]
+      end
+      return res["SerialNumber"]
     end
 
     def getRackGroupIdentifier(host)
       res = callRedfishGetAPI(host, @deviceRackURI[hardware])
-      return res[@deviceIDField[hardware]]
-    end
-
-    def getPowerState(host)
-      res = callRedfishGetAPI(host, @deviceRackURI[hardware])
-      return res["PowerState"]
+      return res["SerialNumber"]
     end
 
     def getPassword()

--- a/test/plugin/test_filter_process_redfishalert.rb
+++ b/test/plugin/test_filter_process_redfishalert.rb
@@ -13,7 +13,8 @@ class ProcessRedfishAlertFilterTest < Test::Unit::TestCase
     @type process_redfishalert
     coloregion testcolo
     username testuser
-    passwordFile 
+    passwordFile
+    hardware SDFLEX
   ]
 
   def create_driver(conf)
@@ -31,12 +32,12 @@ class ProcessRedfishAlertFilterTest < Test::Unit::TestCase
                 return JSON.parse(res)
             end
 
-            def getRackGroupSerialNumber(host)
+            def getRackGroupIdentifier(host)
                 res = callTestRedfishGetAPI(host, "uri")
                 res["SerialNumber"]
             end
 
-            def getRMCSerialNumber(host)
+            def getMachineIdentifier(host)
                 res = callTestRedfishGetAPI(host, "uri")
                 res["SerialNumber"]
             end


### PR DESCRIPTION
Description:
- Current implementation only support SDFLEX hardware. Updated the plugin support dell idrac with hardware passed as cofig_param into the plugin

 

Changes
- Implemented support for dell iDRAC unique identifiers for node and rack, as current implementation only fetch unique identifiers for SDFLEX 
- Changes allows the current implementation to be easily extensible for new hardware the support redfish APIs

 

Testing:
- Funtional testing in using postman and fluented server in a windows vm
- Unit testing 

[test_folder.zip](https://github.com/Azure/fluent-plugin-process-redfishalert/files/6504344/test_folder.zip)
