### PR TITLE
Aditioak/update rmc serial number api

### DIFF
--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -17,6 +17,7 @@ module Fluent
         @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC", "SUPERMICRO" => "Systems/1"]
         @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup", "SUPERMICRO" => "Chassis/1"]
         @deviceIDField = Hash["Dell_PowerEdge_iDRAC"=>"SKU", "SDFLEX" => "SerialNumber", "SUPERMICRO" => "SerialNumber"]
+        @alternativeEndpointForSDFlex = "Managers/RMC"
     end
 
     def start
@@ -70,7 +71,11 @@ module Fluent
     end
 
     def getMachineIdentifier(host)
-      res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      begin
+        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      rescue Net::HTTPNotFound
+        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+      end
       return res[@deviceIDField[hardware]]
     end
 

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -74,7 +74,7 @@ module Fluent
       if @coloregion == "MWH02B"
         begin
           res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-        rescue Net::HTTPNotFound
+        rescue NoMethodError => e
           res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
         end
         return res[@deviceIDField[hardware]]

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -80,6 +80,7 @@ module Fluent
         return res[@deviceIDField[hardware]]
       else
         res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])  
+        return res[@deviceIDField[hardware]]
       end
     end
 

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -71,12 +71,16 @@ module Fluent
     end
 
     def getMachineIdentifier(host)
-      begin
-        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-      rescue Net::HTTPNotFound
-        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+      if @coloregion == "MWH02B"
+        begin
+          res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+        rescue Net::HTTPNotFound
+          res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+        end
+        return res[@deviceIDField[hardware]]
+      else
+        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])  
       end
-      return res[@deviceIDField[hardware]]
     end
 
     def getRackGroupIdentifier(host)


### PR DESCRIPTION
**The flow for fetching RMC Serial Number for SDFlex 280 is:**

1. Call the current available endpoint for SDFlex (Chassis/RMC). If on calling this endpoint, we get an HTTPNotFound error that means the server we're fetching this for is not SDFlex, it is SDFlex 280.
2. On getting an HTTPNotFound error, we run another API relevant for S280 (Managers/RMC)
3. The response for above API will have a field 'SerialNumber' which is then extracted and returned.

For time being these changes are made for testing only in MWH02B. If the colo is anything but this then only the original SDFlex API (Chassis/RMC) will be run.