### PR TITLE
Added fetching of RMC Serial Number for S280 blade 

### DIFF
--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -17,6 +17,7 @@ module Fluent
         @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC", "SUPERMICRO" => "Systems/1"]
         @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup", "SUPERMICRO" => "Chassis/1"]
         @deviceIDField = Hash["Dell_PowerEdge_iDRAC"=>"SKU", "SDFLEX" => "SerialNumber", "SUPERMICRO" => "SerialNumber"]
+        @alternativeEndpointForSDFlex = "Managers/RMC"
     end
 
     def start
@@ -70,7 +71,11 @@ module Fluent
     end
 
     def getMachineIdentifier(host)
-      res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      begin
+        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      rescue Net::HTTPNotFound
+        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+      end
       return res[@deviceIDField[hardware]]
     end
 

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -74,7 +74,7 @@ module Fluent
       if @coloregion == "MWH02B"
         begin
           res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-        rescue Net::HTTPNotFound
+        rescue NoMethodError => e
           res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
         end
         return res[@deviceIDField[hardware]]

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -17,7 +17,7 @@ module Fluent
         @hwtDeviceURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RMC", "SUPERMICRO" => "Systems/1"]
         @deviceRackURI = Hash["Dell_PowerEdge_iDRAC"=>"Systems/System.Embedded.1", "SDFLEX" => "Chassis/RackGroup", "SUPERMICRO" => "Chassis/1"]
         @deviceIDField = Hash["Dell_PowerEdge_iDRAC"=>"SKU", "SDFLEX" => "SerialNumber", "SUPERMICRO" => "SerialNumber"]
-        @alternativeEndpointForSDFlex = "Managers/RMC"
+        @alternativeRMCEndpointForSDFlex = "Managers/RMC"
     end
 
     def start
@@ -74,7 +74,7 @@ module Fluent
       begin
         res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
       rescue NoMethodError => e
-        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+        res = callRedfishGetAPI(host, @alternativeRMCEndpointForSDFlex) if @hardware == "SDFLEX"
       end
       return res[@deviceIDField[hardware]]
     end

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -71,17 +71,12 @@ module Fluent
     end
 
     def getMachineIdentifier(host)
-      if @coloregion == "MWH02B"
-        begin
-          res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-        rescue NoMethodError => e
-          res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
-        end
-        return res[@deviceIDField[hardware]]
-      else
-        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])  
-        return res[@deviceIDField[hardware]]
+      begin
+        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+      rescue NoMethodError => e
+        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
       end
+      return res[@deviceIDField[hardware]]
     end
 
     def getRackGroupIdentifier(host)

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -73,6 +73,7 @@ module Fluent
     def getMachineIdentifier(host)
       begin
         res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+        # alternativeRMCEndpointForSDFlex fetches the SerialNumber from the RMC endpoint for SDFlex 280 blades
       rescue NoMethodError => e
         res = callRedfishGetAPI(host, @alternativeRMCEndpointForSDFlex) if @hardware == "SDFLEX"
       end

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -80,6 +80,7 @@ module Fluent
         return res[@deviceIDField[hardware]]
       else
         res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])  
+        return res[@deviceIDField[hardware]]
       end
     end
 

--- a/lib/fluent/plugin/filter_process_redfishalert.rb
+++ b/lib/fluent/plugin/filter_process_redfishalert.rb
@@ -71,12 +71,16 @@ module Fluent
     end
 
     def getMachineIdentifier(host)
-      begin
-        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
-      rescue Net::HTTPNotFound
-        res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+      if @coloregion == "MWH02B"
+        begin
+          res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])
+        rescue Net::HTTPNotFound
+          res = callRedfishGetAPI(host, @alternativeEndpointForSDFlex) if @hardware == "SDFLEX"
+        end
+        return res[@deviceIDField[hardware]]
+      else
+        res = callRedfishGetAPI(host, @hwtDeviceURI[hardware])  
       end
-      return res[@deviceIDField[hardware]]
     end
 
     def getRackGroupIdentifier(host)


### PR DESCRIPTION
The flow for fetching RMC Serial Number for SDFlex 280 is:

Call the current available endpoint for SDFlex (Chassis/RMC). If on calling this endpoint, we get an HTTPNotFound error that means the server we're fetching this for is not SDFlex, it is SDFlex 280.
On getting an HTTPNotFound error, we run another API relevant for S280 (Managers/RMC)
The response for above API will have a field 'SerialNumber' which is then extracted and returned.

Testing has been done in MWH02B. Events were seen for both SDFlex and SDFlex280:

S280 Event: 
![image](https://github.com/Azure/fluent-plugin-process-redfishalert/assets/138458229/2272ffbc-e845-4c0a-a207-8ab74f142b35)

SDFlex Event:
![image](https://github.com/Azure/fluent-plugin-process-redfishalert/assets/138458229/ef8ac54f-f789-44bc-9277-2dab9527719e)
